### PR TITLE
V0.4.1 bugfix - Correcting AV64 bug

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -189,7 +189,7 @@ module "avm_res_keyvault_vault" {
 module "test_private_cloud" {
   source = "../../"
   # source             = "Azure/avm-res-avs-privatecloud/azurerm"
-  # version            = "=0.4.0"
+  # version            = "=0.4.1"
 
   enable_telemetry           = var.enable_telemetry
   resource_group_name        = azurerm_resource_group.this.name

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -173,7 +173,7 @@ module "avm_res_keyvault_vault" {
 module "test_private_cloud" {
   source = "../../"
   # source             = "Azure/avm-res-avs-privatecloud/azurerm"
-  # version            = "=0.4.0"
+  # version            = "=0.4.1"
 
   enable_telemetry           = var.enable_telemetry
   resource_group_name        = azurerm_resource_group.this.name

--- a/examples/default_vwan/README.md
+++ b/examples/default_vwan/README.md
@@ -194,7 +194,7 @@ module "avm_res_keyvault_vault" {
 module "test_private_cloud" {
   source = "../../"
   # source             = "Azure/avm-res-avs-privatecloud/azurerm"
-  # version            = "=0.4.0"
+  # version            = "=0.4.1"
 
   enable_telemetry           = var.enable_telemetry
   resource_group_name        = azurerm_resource_group.this.name

--- a/examples/default_vwan/README.md
+++ b/examples/default_vwan/README.md
@@ -1,5 +1,5 @@
 <!-- BEGIN_TF_DOCS -->
-# Default AVS example with Vnet ExpressRoute Gateway
+# Default AVS example with VWAN ExpressRoute Gateway
 
 This example demonstrates a deployment with a single Azure VMware Solution private cloud with the following features:
 
@@ -7,7 +7,7 @@ This example demonstrates a deployment with a single Azure VMware Solution priva
     - The HCX Addon enabled with the Enterprise license sku
     - An example HCX site key
     - An ExpressRoute authorization key
-    - An ExpressRoute Gateway connection to an example ExpressRoute gateway in a vwan hub.
+    - An ExpressRoute Gateway connection to an example ExpressRoute gateway in a VWAN hub.
     - Diagnostic Settings to send the syslog and metrics to a Log Analytics workspace.
     - A server 2022 jump virtual machine for vcenter and NSX-t console access with:
         - Nat Gateway enabled for outbound internet access

--- a/examples/default_vwan/_header.md
+++ b/examples/default_vwan/_header.md
@@ -1,4 +1,4 @@
-# Default AVS example with Vnet ExpressRoute Gateway
+# Default AVS example with VWAN ExpressRoute Gateway
 
 This example demonstrates a deployment with a single Azure VMware Solution private cloud with the following features:
 
@@ -6,7 +6,7 @@ This example demonstrates a deployment with a single Azure VMware Solution priva
     - The HCX Addon enabled with the Enterprise license sku
     - An example HCX site key
     - An ExpressRoute authorization key
-    - An ExpressRoute Gateway connection to an example ExpressRoute gateway in a vwan hub.
+    - An ExpressRoute Gateway connection to an example ExpressRoute gateway in a VWAN hub.
     - Diagnostic Settings to send the syslog and metrics to a Log Analytics workspace.
     - A server 2022 jump virtual machine for vcenter and NSX-t console access with:
         - Nat Gateway enabled for outbound internet access

--- a/examples/default_vwan/main.tf
+++ b/examples/default_vwan/main.tf
@@ -178,7 +178,7 @@ module "avm_res_keyvault_vault" {
 module "test_private_cloud" {
   source = "../../"
   # source             = "Azure/avm-res-avs-privatecloud/azurerm"
-  # version            = "=0.4.0"
+  # version            = "=0.4.1"
 
   enable_telemetry           = var.enable_telemetry
   resource_group_name        = azurerm_resource_group.this.name

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -294,7 +294,7 @@ module "create_anf_volume" {
 module "test_private_cloud" {
   source = "../../"
   # source             = "Azure/avm-res-avs-privatecloud/azurerm"
-  # version            = "=0.4.0"
+  # version            = "=0.4.1"
 
   enable_telemetry           = var.enable_telemetry
   resource_group_name        = azurerm_resource_group.this.name

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -1,5 +1,5 @@
 <!-- BEGIN_TF_DOCS -->
-# Default AVS example with Vnet ExpressRoute Gateway
+# Full AVS example with Vnet ExpressRoute Gateway
 
 This example demonstrates most of the deployment inputs using a single Azure VMware Solution private cloud with the following features and supporting test resources:
 

--- a/examples/full/_header.md
+++ b/examples/full/_header.md
@@ -1,4 +1,4 @@
-# Default AVS example with Vnet ExpressRoute Gateway
+# Full AVS example with Vnet ExpressRoute Gateway
 
 This example demonstrates most of the deployment inputs using a single Azure VMware Solution private cloud with the following features and supporting test resources:
 

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -266,7 +266,7 @@ module "create_anf_volume" {
 module "test_private_cloud" {
   source = "../../"
   # source             = "Azure/avm-res-avs-privatecloud/azurerm"
-  # version            = "=0.4.0"
+  # version            = "=0.4.1"
 
   enable_telemetry           = var.enable_telemetry
   resource_group_name        = azurerm_resource_group.this.name

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.4.0"
+    "module_version": "0.4.1"
   }
 }

--- a/main.privatecloud.tf
+++ b/main.privatecloud.tf
@@ -8,16 +8,15 @@ locals {
       name = lower(var.sku_name)
     }
   }
-
   base_properties = {
     managementCluster = {
       clusterSize = var.management_cluster_size
     }
-    
-    networkBlock          = var.avs_network_cidr
-    nsxtPassword          = local.nsxt_password
-    vcenterPassword       = local.vcenter_password
-    internet              = var.internet_enabled ? "Enabled" : "Disabled"
+
+    networkBlock    = var.avs_network_cidr
+    nsxtPassword    = local.nsxt_password
+    vcenterPassword = local.vcenter_password
+    internet        = var.internet_enabled ? "Enabled" : "Disabled"
 
     availability = {
       secondaryZone = var.secondary_zone
@@ -25,16 +24,15 @@ locals {
       strategy      = var.enable_stretch_cluster ? "DualZone" : "SingleZone"
     }
   }
-
+  full_body = jsonencode(merge(local.base_body, { properties = jsondecode(local.properties_map_json) })) #merge the properties map into the body map
   #merge the extended network Blocks value into the properties if it exists
   properties_map_json = (length(var.extended_network_blocks) == 0) ? jsonencode(local.base_properties) : jsonencode(merge(local.base_properties, { extendedNetworkBlocks = var.extended_network_blocks }))
-  full_body = jsonencode(merge(local.base_body, { properties = jsondecode(local.properties_map_json) } )) #merge the properties map into the body map
 }
 
 #build a base private cloud resource then modify it as needed.
 resource "azapi_resource" "this_private_cloud" {
-  type = "Microsoft.AVS/privateClouds@2023-03-01" 
-  body = local.full_body
+  type                   = "Microsoft.AVS/privateClouds@2023-03-01"
+  body                   = local.full_body
   location               = var.location
   name                   = var.name
   parent_id              = var.resource_group_resource_id

--- a/main.privatecloud.tf
+++ b/main.privatecloud.tf
@@ -1,32 +1,40 @@
 #defaulting to azAPI for private cloud provisioning due to issues with feature lag on AzureRM for AVS
 #and need to avoid breaking changes
 
-#build a base private cloud resource then modify it as needed.
-resource "azapi_resource" "this_private_cloud" {
-  type = "Microsoft.AVS/privateClouds@2023-03-01"
-  body = jsonencode({
+#pre-creating the body as a local to allow for handling issues with the API not accepting null values.
+locals {
+  base_body = {
     sku = {
       name = lower(var.sku_name)
     }
-    properties = {
-      managementCluster = {
-        clusterSize = var.management_cluster_size
-      }
+  }
 
-      extendedNetworkBlocks = var.extended_network_blocks
-      networkBlock          = var.avs_network_cidr
-      nsxtPassword          = local.nsxt_password
-      vcenterPassword       = local.vcenter_password
-      internet              = var.internet_enabled ? "Enabled" : "Disabled"
-
-
-      availability = {
-        secondaryZone = var.secondary_zone
-        zone          = var.primary_zone
-        strategy      = var.enable_stretch_cluster ? "DualZone" : "SingleZone"
-      }
+  base_properties = {
+    managementCluster = {
+      clusterSize = var.management_cluster_size
     }
-  })
+    
+    networkBlock          = var.avs_network_cidr
+    nsxtPassword          = local.nsxt_password
+    vcenterPassword       = local.vcenter_password
+    internet              = var.internet_enabled ? "Enabled" : "Disabled"
+
+    availability = {
+      secondaryZone = var.secondary_zone
+      zone          = var.primary_zone
+      strategy      = var.enable_stretch_cluster ? "DualZone" : "SingleZone"
+    }
+  }
+
+  #merge the extended network Blocks value into the properties if it exists
+  properties_map_json = (length(var.extended_network_blocks) == 0) ? jsonencode(local.base_properties) : jsonencode(merge(local.base_properties, { extendedNetworkBlocks = var.extended_network_blocks }))
+  full_body = jsonencode(merge(local.base_body, { properties = jsondecode(local.properties_map_json) } )) #merge the properties map into the body map
+}
+
+#build a base private cloud resource then modify it as needed.
+resource "azapi_resource" "this_private_cloud" {
+  type = "Microsoft.AVS/privateClouds@2023-03-01" 
+  body = local.full_body
   location               = var.location
   name                   = var.name
   parent_id              = var.resource_group_resource_id

--- a/modules/create_jump_vm/main.tf
+++ b/modules/create_jump_vm/main.tf
@@ -34,6 +34,7 @@ module "jumpvm" {
   name                                   = var.vm_name
   admin_credential_key_vault_resource_id = var.key_vault_resource_id
   virtualmachine_sku_size                = var.vm_sku
+  zone                                   = "1"
 
   source_image_reference = {
     publisher = "MicrosoftWindowsServer"


### PR DESCRIPTION
## Description

Fixes #28, Closes #28.  

This is a bug fix release that corrects an issue where an empty extended_network block causes the deployment to error out.  Updated the AzAPI JSON to exclude that field when it is not provided.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x] Azure Verified Module updates:
  - [ x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ x] Update to documentation

# Checklist

- [x ] I'm sure there are no other open Pull Requests for the same update/change
- [x ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
