### PR TITLE
AVS region selector module region updates

### DIFF
--- a/modules/generate_deployment_region/README.md
+++ b/modules/generate_deployment_region/README.md
@@ -9,7 +9,7 @@ locals {
     name = "no_quota"
     sku  = "no_quota"
   }
-  test_regions = ["australiasoutheast", "canadaeast", "eastasia", "eastus2", "germanywestcentral", "qatarcentral", "southafricanorth", "southcentralus", "swedencentral", "uaenorth", "uksouth", "westus2"]
+  test_regions = ["eastasia", "eastus2", "germanywestcentral", "qatarcentral", "southafricanorth", "southcentralus", "swedencentral", "uaenorth", "uksouth", "westus2"]
   with_quota   = concat(local.with_quota_av36, local.with_quota_av36p)
   with_quota_av36 = try([for region in data.azapi_resource_action.quota :
     { name = split("/", region.resource_id)[6], sku = "av36" } if

--- a/modules/generate_deployment_region/main.tf
+++ b/modules/generate_deployment_region/main.tf
@@ -3,7 +3,7 @@ locals {
     name = "no_quota"
     sku  = "no_quota"
   }
-  test_regions = ["australiasoutheast", "canadaeast", "eastasia", "eastus2", "germanywestcentral", "qatarcentral", "southafricanorth", "southcentralus", "swedencentral", "uaenorth", "uksouth", "westus2"]
+  test_regions = ["eastasia", "eastus2", "germanywestcentral", "qatarcentral", "southafricanorth", "southcentralus", "swedencentral", "uaenorth", "uksouth", "westus2"]
   with_quota   = concat(local.with_quota_av36, local.with_quota_av36p)
   with_quota_av36 = try([for region in data.azapi_resource_action.quota :
     { name = split("/", region.resource_id)[6], sku = "av36" } if


### PR DESCRIPTION
## Description

This minor change updates the region/sku selector tool to remove regions that don't support zones.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
