### PR TITLE
Updated the docs for the AVS deployment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Type: `string`
 
 ### <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name)
 
-Description: The sku value for the AVS SDDC management cluster nodes. Valid values are av20, av36, av36t, av36pt, av48, av52, and av64.
+Description: The sku value for the AVS SDDC management cluster nodes. Valid values are av20, av36, av36p, av36t, av36pt, av48, av52, and av64.
 
 Type: `string`
 
@@ -452,7 +452,7 @@ Description: Map of string objects describing one or more ExpressRoute connectio
   - `routing_weight`                       = (Optional) - The routing weight value to use for this connection.  Defaults to 0.
   - `enable_internet_security`             = (Optional) - Set this to true if connecting to a secure VWAN hub and you want the hub NVA to publish a default route to AVS.
   - `tags`                                 = (Optional) - Map of strings describing any custom tags to apply to this connection resource
-  - `network_resource_group_resource_id`   = (Optional) - The resource ID of an external resource group. This is used to place the virtual network gateway connection resource with the virtual network gateway if the gateway is in a separate location.
+  - `network_resource_group_resource_id`   = (Optional) - The resource ID of an external resource group, **must be the same resource group as the virtual network gateway you are connecting to**. This is used to place the virtual network gateway connection resource with the virtual network gateway if the gateway is in a separate location.
   - `network_resource_group_location`      = (Optional) - The location of an external resource group. This is used to place the virtual network gateway connection resource with the virtual network gateway if the gateway is in a separate location.
   - `routing`                              = (Optional) - Map of objects used to describe any VWAN and Virtual Hub custom routing for this connection
     - `associated_route_table_resource_id` = (Optional) - The Azure Resource ID of the Virtual Hub Route Table associated with this Express Route Connection.
@@ -716,7 +716,7 @@ Description: This map object describes the additional segments to configure on t
 
 - `<map key>` - Provide a key value that will be used as the segment name
   - `display_name`       = (Required) - The display name for the dhcp configuration being created
-  - `gateway_address`    = (Required) - The CIDR range to use for the segment
+  - `gateway_address`    = (Required) - The CIDR range to use for the segment, starting with the gateway address.  Example: `10.20.0.1/24` **notice the range starts with `1` and not `0`**.
   - `dhcp_ranges`        = (Optional) - One or more ranges of IP addresses or CIDR blocks entered as a list of string
   - `connected_gateway`  = (Optional) - The name of the T1 gateway to connect this segment to.  Defaults to the managed t1 gateway if left unconfigured.
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "resource_group_resource_id" {
 
 variable "sku_name" {
   type        = string
-  description = "The sku value for the AVS SDDC management cluster nodes. Valid values are av20, av36, av36t, av36pt, av48, av52, and av64."
+  description = "The sku value for the AVS SDDC management cluster nodes. Valid values are av20, av36, av36p, av36t, av36pt, av48, av52, and av64."
 }
 
 variable "addons" {
@@ -368,7 +368,7 @@ Map of string objects describing one or more ExpressRoute connections to be conf
   - `routing_weight`                       = (Optional) - The routing weight value to use for this connection.  Defaults to 0.
   - `enable_internet_security`             = (Optional) - Set this to true if connecting to a secure VWAN hub and you want the hub NVA to publish a default route to AVS.
   - `tags`                                 = (Optional) - Map of strings describing any custom tags to apply to this connection resource
-  - `network_resource_group_resource_id`   = (Optional) - The resource ID of an external resource group. This is used to place the virtual network gateway connection resource with the virtual network gateway if the gateway is in a separate location.
+  - `network_resource_group_resource_id`   = (Optional) - The resource ID of an external resource group, **must be the same resource group as the virtual network gateway you are connecting to**. This is used to place the virtual network gateway connection resource with the virtual network gateway if the gateway is in a separate location.
   - `network_resource_group_location`      = (Optional) - The location of an external resource group. This is used to place the virtual network gateway connection resource with the virtual network gateway if the gateway is in a separate location.
   - `routing`                              = (Optional) - Map of objects used to describe any VWAN and Virtual Hub custom routing for this connection
     - `associated_route_table_resource_id` = (Optional) - The Azure Resource ID of the Virtual Hub Route Table associated with this Express Route Connection.
@@ -586,7 +586,7 @@ This map object describes the additional segments to configure on the private cl
 
 - `<map key>` - Provide a key value that will be used as the segment name
   - `display_name`       = (Required) - The display name for the dhcp configuration being created
-  - `gateway_address`    = (Required) - The CIDR range to use for the segment
+  - `gateway_address`    = (Required) - The CIDR range to use for the segment, starting with the gateway address.  Example: `10.20.0.1/24` **notice the range starts with `1` and not `0`**.
   - `dhcp_ranges`        = (Optional) - One or more ranges of IP addresses or CIDR blocks entered as a list of string
   - `connected_gateway`  = (Optional) - The name of the T1 gateway to connect this segment to.  Defaults to the managed t1 gateway if left unconfigured.
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

-->

## Type of Change

Added additional clarificaitons on the sku supported (av36p), express route connection resource group must be the same as the virtual network gateway you are connecting to.

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
