### PR TITLE
Fixes bug where run commands fail for ldap configuration

### DIFF
--- a/main.ldaps.tf
+++ b/main.ldaps.tf
@@ -20,7 +20,7 @@ resource "azapi_resource" "remove_existing_identity_source" {
     properties = {
       timeout        = "PT15M"
       retention      = "P30D"
-      scriptCmdletId = "${azapi_resource.this_private_cloud.id}/scriptPackages/Microsoft.AVS.Management@*/scriptCmdlets/Remove-ExternalIdentitySources"
+      scriptCmdletId = "${azapi_resource.this_private_cloud.id}/scriptPackages/Microsoft.AVS.Identity@*/scriptCmdlets/Remove-ExternalIdentitySources"
       DomainName     = each.value.domain
     }
     }
@@ -76,7 +76,7 @@ resource "azapi_resource" "configure_identity_sources" {
     properties = {
       timeout        = "PT15M"
       retention      = "P30D"
-      scriptCmdletId = "${azapi_resource.this_private_cloud.id}/scriptPackages/Microsoft.AVS.Management@*/scriptCmdlets/${each.value.ssl == "Enabled" ? "New-LDAPSIdentitySource" : "New-LDAPIdentitySource"}"
+      scriptCmdletId = "${azapi_resource.this_private_cloud.id}/scriptPackages/Microsoft.AVS.Identity@*/scriptCmdlets/${each.value.ssl == "Enabled" ? "New-LDAPSIdentitySource" : "New-LDAPIdentitySource"}"
       hiddenParameters = [{
         name     = "Credential"
         type     = "Credential"


### PR DESCRIPTION
## Description
The LDAP run commands were moved to a new run command module in AVS causing the ldap configuration code in the module to error out.  Updated the reference to the new module.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
